### PR TITLE
changed the width of the input on focus instead of hover

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -191,7 +191,7 @@ main {
 	font-weight: 600;
 }
 
-.api-test form input:hover {
+.api-test form input:focus {
 	width: 70%;
 }
 


### PR DESCRIPTION
Now, the input doesn't change its width when you're not hovering it.